### PR TITLE
Support for child watchers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
   ADD_TEST(ev_timer ${LUA} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_ev_timer.lua ${CMAKE_CURRENT_SOURCE_DIR}/test/ ${CMAKE_CURRENT_BINARY_DIR}/)
   ADD_TEST(ev_idle ${LUA} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_ev_idle.lua ${CMAKE_CURRENT_SOURCE_DIR}/test/ ${CMAKE_CURRENT_BINARY_DIR}/)
   ADD_TEST(ev_signal ${LUA} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_ev_signal.lua ${CMAKE_CURRENT_SOURCE_DIR}/test/ ${CMAKE_CURRENT_BINARY_DIR}/)
-  SET_TESTS_PROPERTIES(ev_io ev_loop ev_timer ev_signal ev_idle
+  ADD_TEST(ev_child ${LUA} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_ev_child.lua ${CMAKE_CURRENT_SOURCE_DIR}/test/ ${CMAKE_CURRENT_BINARY_DIR}/)
+  SET_TESTS_PROPERTIES(ev_io ev_loop ev_timer ev_signal ev_idle ev_child
                        PROPERTIES
                        FAIL_REGULAR_EXPRESSION
                        "not ok")

--- a/README
+++ b/README
@@ -174,6 +174,34 @@ idle = ev.Idle.new(on_idle)
 
     See also ev_idle_init() C function.
 
+child = ev.Child.new(on_child, pid, trace)
+
+    Create a new child watcher that will call the on_child function
+    whenever SIGCHLD for registered pid is delivered.
+
+    When pid is set to 0 the watcher will fire for any pid.
+
+    When trace is false the watcher will be activated when the process
+    terminates. If it's true - it will additionally be activated when
+    the process is stopped or continued.
+
+    The returned child is an ev.Child object.  See below for the methods on
+    this object.
+
+    NOTE: You must explicitly register the idle with an event loop in
+    order for it to take effect.
+
+    The on_child function will be called with these arguments (return
+    values are ignored):
+
+    on_child(loop, child, revents)
+
+        The loop is the event loop for which the idle object is
+        registered, the child parameter is the ev.Child object, and
+        revents is ev.CHILD.
+
+    See also ev_child_init() C function.
+
 ev.READ (constant)
 
     If this bit is set, the io watcher is ready to read.  See also
@@ -193,6 +221,11 @@ ev.SIGNAL (constant)
 
    If this bit is set, the watcher was triggered by a signal.  See
    also EV_SIGNAL C definition.
+
+ev.CHILD (constant)
+
+   If this bit is set, the watcher was triggered by a child signal.
+   See also EV_CHILD C definition.
 
 -- ev.Loop object methods --
 
@@ -365,6 +398,52 @@ idle:stop(loop)
 
     See also ev_io_stop() C function (document as ev_TYPE_stop()).
 
+-- ev.Child object methods --
+
+child:start(loop [, is_daemon])
+
+    Start the child watcher in the specified event loop.  Optionally
+    make this watcher a "daemon" watcher which means that the event
+    loop will terminate even if this watcher has not triggered.
+
+    See also ev_child_start() C function (document as ev_TYPE_start()).
+
+child:stop(loop)
+
+    Unregister this child watcher from the specified event loop.
+    Ensures that the watcher is neither active nor pending.
+
+    See also ev_child_stop() C function (document as ev_TYPE_stop()).
+
+child:getpid()
+
+    Return the process id this watcher watches out for, or 0, meaning
+    any process id.
+
+child:getrpid()
+
+    Return the process id that detected a status change.
+
+child:getstatus()
+
+    Returns the process exit/trace status caused by "rpid" (see your systems
+    "waitpid" and "sys/wait.h" for details).
+
+    It returns the table with the following fields:
+    - exited: true if status was returned for a child process that terminated
+      normally;
+    - stopped: true if status was returned for a child process that is
+      currently stopped;
+    - signaled: true if status was returned for a child process that terminated
+      due to receipt of a signal that was not caught;
+    - exit_status: (only if exited == true) the low-order 8 bits of the status
+      argument that the child process passed to _exit() or exit(), or the value
+      the child process returned from main();
+    - stop_signal: (only if stopped == true) the number of the signal that
+      caused the child process to stop;
+    - term_signal: (only if signaled == true) the number of the signal that
+      caused the termination of the child process.
+
 EXCEPTION HANDLING NOTE:
 
    If there is an exception when calling a watcher callback, the error
@@ -401,6 +480,6 @@ CALLING ev_loop() C API DIRECTLY:
 
 TODO:
 
-  * Add support for other watcher types (stat, periodic, child, embed,
+  * Add support for other watcher types (stat, periodic, embed,
     async, etc).
 

--- a/child_lua_ev.c
+++ b/child_lua_ev.c
@@ -1,0 +1,210 @@
+#include <sys/wait.h>
+
+#define luaL_checkbool(L, i) (lua_isboolean(L, i) ? lua_toboolean(L, i) : luaL_checkint(L, i))
+
+/**
+ * Create a table for ev.CHILD that gives access to the constructor for
+ * child objects.
+ *
+ * [-0, +1, ?]
+ */
+static int luaopen_ev_child(lua_State *L) {
+    lua_pop(L, create_child_mt(L));
+
+    lua_createtable(L, 0, 1);
+
+    lua_pushcfunction(L, child_new);
+    lua_setfield(L, -2, "new");
+
+    return 1;
+}
+
+/**
+ * Create the child metatable in the registry.
+ *
+ * [-0, +1, ?]
+ */
+static int create_child_mt(lua_State *L) {
+    static luaL_reg fns[] = {
+        { "stop",          child_stop },
+        { "start",         child_start },
+        { "getpid" ,       child_getpid },
+        { "getrpid" ,      child_getrpid },
+        { "getstatus" ,    child_getstatus },
+        { NULL, NULL }
+    };
+    luaL_newmetatable(L, CHILD_MT);
+    add_watcher_mt(L);
+    luaL_register(L, NULL, fns);
+
+    return 1;
+}
+
+/**
+ * Create a new child object.  Arguments:
+ *   1 - callback function.
+ *   2 - pid number (0 for any pid)
+ *   3 - trace (either false - only activate the watcher when the process
+ *       terminates or true - additionally activate the watcher when the
+ *       process is stopped or continued).
+ *
+ * @see watcher_new()
+ *
+ * [+1, -0, ?]
+ */
+static int child_new(lua_State* L) {
+    int         pid = luaL_checkint(L, 2);
+    int         trace = luaL_checkbool(L, 3);
+    ev_child*   child;
+
+    child = watcher_new(L, sizeof(ev_child), CHILD_MT);
+    ev_child_init(child, &child_cb, pid, trace);
+    return 1;
+}
+
+/**
+ * @see watcher_cb()
+ *
+ * [+0, -0, m]
+ */
+static void child_cb(struct ev_loop* loop, ev_child* child, int revents) {
+    watcher_cb(loop, child, revents);
+}
+
+/**
+ * Stops the child so it won't be called by the specified event loop.
+ *
+ * Usage:
+ *     child:stop(loop)
+ *
+ * [+0, -0, e]
+ */
+static int child_stop(lua_State *L) {
+    ev_child*       child  = check_child(L, 1);
+    struct ev_loop* loop = *check_loop_and_init(L, 2);
+
+    loop_stop_watcher(L, 2, 1);
+    ev_child_stop(loop, child);
+
+    return 0;
+}
+
+/**
+ * Starts the child so it will be called by the specified event loop.
+ *
+ * Usage:
+ *     child:start(loop [, is_daemon])
+ *
+ * [+0, -0, e]
+ */
+static int child_start(lua_State *L) {
+    ev_child*       child = check_child(L, 1);
+    struct ev_loop* loop = *check_loop_and_init(L, 2);
+    int is_daemon        = lua_toboolean(L, 3);
+
+    ev_child_start(loop, child);
+    loop_start_watcher(L, 2, 1, is_daemon);
+
+    return 0;
+}
+
+/**
+ * Returns the child pid (the process id this watcher watches out for, or 0,
+ * meaning any process id).
+ * Usage:
+ *     child:getpid()
+ *
+ * [+1, -0, e]
+ */
+static int child_getpid(lua_State *L) {
+    ev_child*       child  = check_child(L, 1);
+
+    lua_pushinteger (L, child->pid);
+
+    return 1;
+}
+
+/**
+ * Returns the child rpid (the process id that detected a status change).
+ * Usage:
+ *     child:getrpid()
+ *
+ * [+1, -0, e]
+ */
+static int child_getrpid(lua_State *L) {
+    ev_child*       child  = check_child(L, 1);
+
+    lua_pushinteger (L, child->rpid);
+
+    return 1;
+}
+
+/**
+ * Returns the process exit/trace status caused by "rpid" (see your systems
+ * "waitpid" and "sys/wait.h" for details).
+ * Usage:
+ *     child:getstatus()
+ *
+ * It returns the table with the following fields:
+ * - exited: true if status was returned for a child process that terminated
+ *   normally;
+ * - stopped: true if status was returned for a child process that is currently
+ *   stopped;
+ * - signaled: true if status was returned for a child process that terminated
+ *   due to receipt of a signal that was not caught;
+ * - exit_status: (only if exited == true) the low-order 8 bits of the status
+ *   argument that the child process passed to _exit() or exit(), or the value
+ *   the child process returned from main();
+ * - stop_signal: (only if stopped == true) the number of the signal that
+ *   caused the child process to stop;
+ * - term_signal: (only if signaled == true) the number of the signal that 
+ *   caused the termination of the child process.
+ *
+ * [+1, -0, e]
+ */
+static int child_getstatus(lua_State *L) {
+    ev_child*       child  = check_child(L, 1);
+    int             exited, stopped, signaled;
+
+    lua_newtable(L);
+
+    exited = WIFEXITED(child->rstatus);
+    stopped = WIFSTOPPED(child->rstatus);
+    signaled = WIFSIGNALED(child->rstatus);
+
+    lua_pushstring(L, "status");
+    lua_pushinteger(L, child->rstatus);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "exited");
+    lua_pushboolean(L, exited);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "stopped");
+    lua_pushboolean(L, stopped);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "signaled");
+    lua_pushboolean(L, signaled);
+    lua_settable(L, -3);
+
+    if (exited) {
+        lua_pushstring(L, "exit_status");
+        lua_pushinteger(L, WEXITSTATUS(child->rstatus));
+        lua_settable(L, -3);
+    }
+
+    if (stopped) {
+        lua_pushstring(L, "stop_signal");
+        lua_pushinteger(L, WSTOPSIG(child->rstatus));
+        lua_settable(L, -3);
+    }
+
+    if (signaled) {
+        lua_pushstring(L, "term_signal");
+        lua_pushinteger(L, WTERMSIG(child->rstatus));
+        lua_settable(L, -3);
+    }
+
+    return 1;
+}

--- a/lua_ev.c
+++ b/lua_ev.c
@@ -14,6 +14,7 @@
 #include "timer_lua_ev.c"
 #include "signal_lua_ev.c"
 #include "idle_lua_ev.c"
+#include "child_lua_ev.c"
 
 static const luaL_reg R[] = {
     {"version", version},
@@ -50,6 +51,9 @@ LUALIB_API int luaopen_ev(lua_State *L) {
     luaopen_ev_idle(L);
     lua_setfield(L, -2, "Idle");
 
+    luaopen_ev_child(L);
+    lua_setfield(L, -2, "Child");
+
     lua_pushnumber(L, EV_READ);
     lua_setfield(L, -2, "READ");
 
@@ -64,6 +68,9 @@ LUALIB_API int luaopen_ev(lua_State *L) {
 
     lua_pushnumber(L, EV_IDLE);
     lua_setfield(L, -2, "IDLE");
+
+    lua_pushnumber(L, EV_CHILD);
+    lua_setfield(L, -2, "CHILD");
 
     lua_pushnumber(L, EV_MINPRI);
     lua_setfield(L, -2, "MINPRI");

--- a/lua_ev.h
+++ b/lua_ev.h
@@ -22,6 +22,7 @@
 #define TIMER_MT   "ev{timer}"
 #define SIGNAL_MT  "ev{signal}"
 #define IDLE_MT    "ev{idle}"
+#define CHILD_MT   "ev{child}"
 
 /**
  * Special token to represent the uninitialized default loop.  This is
@@ -67,6 +68,9 @@
 
 #define check_idle(L, narg)                                      \
     ((struct ev_idle*)     luaL_checkudata((L), (narg), IDLE_MT))
+
+#define check_child(L, narg)                                      \
+    ((struct ev_child*)     luaL_checkudata((L), (narg), CHILD_MT))
 
 
 /**
@@ -172,3 +176,16 @@ static int               idle_new(lua_State* L);
 static void              idle_cb(struct ev_loop* loop, ev_idle* idle, int revents);
 static int               idle_stop(lua_State *L);
 static int               idle_start(lua_State *L);
+
+/**
+ * Child functions:
+ */
+static int               luaopen_ev_child(lua_State *L);
+static int               create_child_mt(lua_State *L);
+static int               child_new(lua_State* L);
+static void              child_cb(struct ev_loop* loop, ev_child* sig, int revents);
+static int               child_stop(lua_State *L);
+static int               child_start(lua_State *L);
+static int               child_getpid(lua_State *L);
+static int               child_getrpid(lua_State *L);
+static int               child_getstatus(lua_State *L);

--- a/test/test_ev_child.lua
+++ b/test/test_ev_child.lua
@@ -1,0 +1,52 @@
+local src_dir, build_dir = ...
+package.path  = src_dir .. "?.lua;" .. package.path
+package.cpath = build_dir .. "?.so;" .. package.cpath
+
+local tap   = require("tap")
+local ev    = require("ev")
+local help  = require("help")
+local dump  = require("dumper").dump
+local ok    = tap.ok
+local alien = require("alien")
+
+local noleaks = help.collect_and_assert_no_watchers
+local loop    = ev.Loop.default
+
+function spawn(cmd)
+    local fork = alien.default.fork
+    local exec = alien.default.execl
+
+    cmd = cmd or 'echo -e ""'
+
+    fork:types('int')
+    exec:types('int', 'string', 'string', 'string', 'string', 'string')
+    
+    local pid = fork()
+
+    if (pid == 0) then
+        local ret = exec('/bin/sh', '/bin/sh', '-c', cmd, nil)
+        ok(not ret, 'shouldn\'t get here, ret: ' .. tostring(ret))
+    else
+        return pid
+    end
+end
+
+function test_basic()
+    local pid
+    local child = ev.Child.new(function(loop, child, revents)
+        local status = child:getstatus()
+        ok(child:getrpid() == pid, 'got proper pid')
+        ok(child:getpid() == 0, 'pid == 0')
+        ok(status.exited, 'process exited')
+        ok(status.exit_status == 0, 'process exited with exit status == 0')
+        ok(status.stopped == false, 'process not stopped')
+        ok(status.signaled == false, 'process not signaled')
+        child:stop(loop)
+    end, 0, false)
+    child:start(loop)
+    pid = spawn()
+    ok(pid > -1, 'fork successful')
+    loop:loop()
+end
+
+noleaks(test_basic, "test_basic")


### PR DESCRIPTION
Hi,

I've added a support for child watchers to your lua-ev library. Please let me know if my changes fit your standards and/or let me know what you would like to see changed/improved/fixed.

Note that `test_ev_child.lua` requires Lua Alien - I needed fork()/exec() functionality.

I'm currently working on stat watchers (it's mostly done - I need to update documentation and write a couple of tests).

**Edit:** Of course I forgot to add `child_lua_ev.c` to the repo. It's fixed now.
## 

Best regards,
Kamil Klimkiewicz
