### PR TITLE
Support external loop state.

### DIFF
--- a/child_lua_ev.c
+++ b/child_lua_ev.c
@@ -105,7 +105,7 @@ static int child_start(lua_State *L) {
     int is_daemon        = lua_toboolean(L, 3);
 
     ev_child_start(loop, child);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, child, 2, 1, is_daemon);
 
     return 0;
 }

--- a/idle_lua_ev.c
+++ b/idle_lua_ev.c
@@ -91,7 +91,7 @@ static int idle_start(lua_State *L) {
     int is_daemon          = lua_toboolean(L, 3);
 
     ev_idle_start(loop, idle);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, idle, 2, 1, is_daemon);
 
     return 0;
 }

--- a/io_lua_ev.c
+++ b/io_lua_ev.c
@@ -96,7 +96,7 @@ static int io_start(lua_State *L) {
     int is_daemon          = lua_toboolean(L, 3);
 
     ev_io_start(loop, io);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, io, 2, 1, is_daemon);
 
     return 0;
 }

--- a/loop_lua_ev.c
+++ b/loop_lua_ev.c
@@ -128,8 +128,11 @@ static int loop_delete(lua_State *L) {
  *
  * [-0, +0, m]
  */
-static void loop_start_watcher(lua_State* L, int loop_i, int watcher_i, int is_daemon) {
+static void loop_start_watcher(lua_State* L, void *watcher, int loop_i, int watcher_i, int is_daemon) {
     int current_is_daemon = -1;
+    ev_watcher *watch = watcher;
+
+    watch->data = L;
 
     loop_i    = abs_index(L, loop_i);
     watcher_i = abs_index(L, watcher_i);
@@ -257,10 +260,7 @@ static int loop_update_now(lua_State *L) {
  */
 static int loop_loop(lua_State *L) {
     struct ev_loop *loop = *check_loop_and_init(L, 1);
-    void *old_userdata = ev_userdata(loop);
-    ev_set_userdata(loop, L);
     ev_loop(loop, 0);
-    ev_set_userdata(loop, old_userdata);
     return 0;
 }
 

--- a/lua_ev.h
+++ b/lua_ev.h
@@ -102,7 +102,7 @@ static struct ev_loop**  loop_alloc(lua_State *L);
 static struct ev_loop**  check_loop_and_init(lua_State *L, int loop_i);
 static int               loop_new(lua_State *L);
 static int               loop_delete(lua_State *L);
-static void              loop_start_watcher(lua_State* L, int loop_i, int watcher_i, int is_daemon);
+static void              loop_start_watcher(lua_State* L, void *watcher, int loop_i, int watcher_i, int is_daemon);
 static void              loop_stop_watcher(lua_State* L, int loop_i, int watcher_i);
 static int               loop_is_default(lua_State *L);
 static int               loop_iteration(lua_State *L);

--- a/signal_lua_ev.c
+++ b/signal_lua_ev.c
@@ -93,7 +93,7 @@ static int signal_start(lua_State *L) {
     int is_daemon        = lua_toboolean(L, 3);
 
     ev_signal_start(loop, sig);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, sig, 2, 1, is_daemon);
 
     return 0;
 }

--- a/stat_lua_ev.c
+++ b/stat_lua_ev.c
@@ -96,7 +96,7 @@ static int stat_start(lua_State *L) {
     int is_daemon        = lua_toboolean(L, 3);
 
     ev_stat_start(loop, stat);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, stat, 2, 1, is_daemon);
 
     return 0;
 }

--- a/timer_lua_ev.c
+++ b/timer_lua_ev.c
@@ -96,7 +96,7 @@ static int timer_again(lua_State *L) {
 
     if ( timer->repeat ) {
         ev_timer_again(loop, timer);
-        loop_start_watcher(L, 2, 1, -1);
+        loop_start_watcher(L, timer, 2, 1, -1);
     } else {
         /* Just calling stop instead of again in case the symantics
          * change in libev */
@@ -139,7 +139,7 @@ static int timer_start(lua_State *L) {
     int is_daemon          = lua_toboolean(L, 3);
 
     ev_timer_start(loop, timer);
-    loop_start_watcher(L, 2, 1, is_daemon);
+    loop_start_watcher(L, timer, 2, 1, is_daemon);
 
     return 0;
 }

--- a/watcher_lua_ev.c
+++ b/watcher_lua_ev.c
@@ -130,9 +130,9 @@ static void* watcher_new(lua_State* L, size_t size, const char* lua_type) {
  * [+0, -0, m]
  */
 static void watcher_cb(struct ev_loop *loop, void *watcher, int revents) {
-    lua_State* L       = ev_userdata(loop);
-    void*      objs[3] = { loop, watcher, NULL };
-    int        result;
+    lua_State*  L       = ((ev_watcher *) watcher)->data;
+    void*       objs[3] = { loop, watcher, NULL };
+    int         result;
 
     lua_pushcfunction(L, traceback);
 


### PR DESCRIPTION
Hi,

thanks for this great library! I'd like to use this with awesome, a X11 window manager. This uses libev's default loop internally and thus adding watchers to ev.Loop.default should just work. There is just one minor problem which this patch tries to fix.

What do you think?
