### PR TITLE
Update lua-ev for Lua 5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
   SET(INSTALL_CMOD share/lua/cmod CACHE PATH "Directory to install Lua binary modules (configure lua via LUA_CPATH)")
 # / configs
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
 # Find libev
   FIND_LIBRARY (LIBEV_LIBRARY NAMES ev)
   FIND_PATH (LIBEV_INCLUDE_DIR ev.h
@@ -24,7 +26,7 @@ CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
 # / Find libarchive
 
 # Find lua
-  FIND_PACKAGE(Lua51 REQUIRED)
+  FIND_PACKAGE(Lua52 REQUIRED)
 # / Find lua
 
 # Define how to build ev.so:

--- a/child_lua_ev.c
+++ b/child_lua_ev.c
@@ -27,7 +27,7 @@ static int luaopen_ev_child(lua_State *L) {
  * [-0, +1, ?]
  */
 static int create_child_mt(lua_State *L) {
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "stop",          child_stop },
         { "start",         child_start },
         { "getpid" ,       child_getpid },
@@ -37,7 +37,11 @@ static int create_child_mt(lua_State *L) {
     };
     luaL_newmetatable(L, CHILD_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }

--- a/cmake/Modules/FindLua52.cmake
+++ b/cmake/Modules/FindLua52.cmake
@@ -1,0 +1,46 @@
+
+find_path(LUA_INCLUDE_DIR lua.h
+	HINTS
+	$ENV{LUA_DIR}
+	PATH_SUFFIXES include/lua52 include/lua5.2 include/lua include
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw
+	/opt/local
+	/opt/csw
+	/opt
+)
+
+find_library(LUA_LIBRARY
+	NAMES lua52 lua5.2 lua-5.2 lua
+	HINTS
+	$ENV{LUA_DIR}
+	PATH_SUFFIXES lib64 lib
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw
+	/opt/local
+	/opt/csw
+	/opt
+)
+
+if(LUA_LIBRARY)
+	if(UNIX AND NOT APPLE)
+		find_library(LUA_MATH_LIBRARY m)
+		set( LUA_LIBRARIES "${LUA_LIBRARY};${LUA_MATH_LIBRARY}" CACHE STRING "Lua Libraries")
+	else(UNIX AND NOT APPLE)
+		set( LUA_LIBRARIES "${LUA_LIBRARY}" CACHE STRING "Lua Libraries")
+	endif(UNIX AND NOT APPLE)
+endif(LUA_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(Lua52 DEFAULT_MSG LUA_LIBRARIES LUA_INCLUDE_DIR)
+
+mark_as_advanced(LUA_INCLUDE_DIR LUA_LIBRARIES LUA_LIBRARY LUA_MATH_LIBRARY)

--- a/idle_lua_ev.c
+++ b/idle_lua_ev.c
@@ -22,14 +22,18 @@ static int luaopen_ev_idle(lua_State *L) {
  */
 static int create_idle_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "stop",          idle_stop },
         { "start",         idle_start },
         { NULL, NULL }
     };
     luaL_newmetatable(L, IDLE_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }

--- a/io_lua_ev.c
+++ b/io_lua_ev.c
@@ -22,7 +22,7 @@ static int luaopen_ev_io(lua_State *L) {
  */
 static int create_io_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "stop",          io_stop },
         { "start",         io_start },
         { "getfd" ,        io_getfd },
@@ -30,7 +30,11 @@ static int create_io_mt(lua_State *L) {
     };
     luaL_newmetatable(L, IO_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }

--- a/loop_lua_ev.c
+++ b/loop_lua_ev.c
@@ -25,7 +25,7 @@ static int luaopen_ev_loop(lua_State *L) {
  */
 static int create_loop_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "is_default", loop_is_default },
         { "count",      loop_iteration }, /* old API */
         { "iteration",  loop_iteration },
@@ -40,7 +40,11 @@ static int create_loop_mt(lua_State *L) {
         { NULL, NULL }
     };
     luaL_newmetatable(L, LOOP_MT);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
     lua_pushvalue(L, -1);
     lua_setfield(L, -2, "__index");
 
@@ -135,7 +139,11 @@ static void loop_start_watcher(lua_State* L, int loop_i, int watcher_i, int is_d
     watcher_i = abs_index(L, watcher_i);
 
     /* Check that watcher isn't already registered: */
+#if LUA_VERSION_NUM > 501
+    lua_getuservalue(L, loop_i);
+#else
     lua_getfenv(L,     loop_i);
+#endif
     lua_pushvalue(L,   watcher_i);
     lua_rawget(L,      -2);
 
@@ -187,7 +195,11 @@ static void loop_stop_watcher(lua_State* L, int loop_i, int watcher_i) {
     loop_i    = abs_index(L, loop_i);
     watcher_i = abs_index(L, watcher_i);
 
+#if LUA_VERSION_NUM > 501
+    lua_getuservalue(L, loop_i);
+#else
     lua_getfenv(L,     loop_i);
+#endif
     lua_pushvalue(L,   watcher_i);
     lua_rawget(L,      -2);
 

--- a/lua_ev.c
+++ b/lua_ev.c
@@ -18,11 +18,12 @@
 #include "child_lua_ev.c"
 #include "stat_lua_ev.c"
 
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
     {"version", version},
     {"object_count", obj_count},
     {NULL, NULL},
 };
+
 
 /**
  * Entry point into the 'ev' lua library.  Validates that the
@@ -36,7 +37,11 @@ LUALIB_API int luaopen_ev(lua_State *L) {
 
     create_obj_registry(L);
 
+#if LUA_VERSION_NUM > 501
+    luaL_newlib(L, R);
+#else
     luaL_register(L, "ev", R);
+#endif
 
     luaopen_ev_loop(L);
     lua_setfield(L, -2, "Loop");
@@ -59,125 +64,53 @@ LUALIB_API int luaopen_ev(lua_State *L) {
     luaopen_ev_stat(L);
     lua_setfield(L, -2, "Stat");
 
-    lua_pushnumber(L, EV_READ);
-    lua_setfield(L, -2, "READ");
+#define EV_SETCONST(state, prefix, C) \
+    lua_pushnumber(L, prefix ## C); \
+    lua_setfield(L, -2, #C)
 
-    lua_pushnumber(L, EV_WRITE);
-    lua_setfield(L, -2, "WRITE");
+    EV_SETCONST(L, EV_, CHILD);
+    EV_SETCONST(L, EV_, IDLE);
+    EV_SETCONST(L, EV_, MINPRI);
+    EV_SETCONST(L, EV_, MAXPRI);
+    EV_SETCONST(L, EV_, READ);
+    EV_SETCONST(L, EV_, SIGNAL);
+    EV_SETCONST(L, EV_, STAT);
+    EV_SETCONST(L, EV_, TIMEOUT);
+    EV_SETCONST(L, EV_, WRITE);
 
-    lua_pushnumber(L, EV_TIMEOUT);
-    lua_setfield(L, -2, "TIMEOUT");
+    EV_SETCONST(L, , SIGABRT);
+    EV_SETCONST(L, , SIGALRM);
+    EV_SETCONST(L, , SIGBUS);
+    EV_SETCONST(L, , SIGCHLD);
+    EV_SETCONST(L, , SIGCONT);
+    EV_SETCONST(L, , SIGFPE);
+    EV_SETCONST(L, , SIGHUP);
+    EV_SETCONST(L, , SIGINT);
+    EV_SETCONST(L, , SIGIO);
+    EV_SETCONST(L, , SIGIOT);
+    EV_SETCONST(L, , SIGKILL);
+    EV_SETCONST(L, , SIGPIPE);
+    EV_SETCONST(L, , SIGPOLL);
+    EV_SETCONST(L, , SIGPROF);
+    EV_SETCONST(L, , SIGPWR);
+    EV_SETCONST(L, , SIGQUIT);
+    EV_SETCONST(L, , SIGSEGV);
+    EV_SETCONST(L, , SIGSTKFLT);
+    EV_SETCONST(L, , SIGSYS);
+    EV_SETCONST(L, , SIGTERM);
+    EV_SETCONST(L, , SIGTRAP);
+    EV_SETCONST(L, , SIGTSTP);
+    EV_SETCONST(L, , SIGTTIN);
+    EV_SETCONST(L, , SIGTTOU);
+    EV_SETCONST(L, , SIGURG);
+    EV_SETCONST(L, , SIGUSR1);
+    EV_SETCONST(L, , SIGUSR2);
+    EV_SETCONST(L, , SIGVTALRM);
+    EV_SETCONST(L, , SIGWINCH);
+    EV_SETCONST(L, , SIGXCPU);
+    EV_SETCONST(L, , SIGXFSZ);
 
-    lua_pushnumber(L, EV_SIGNAL);
-    lua_setfield(L, -2, "SIGNAL");
-
-    lua_pushnumber(L, EV_IDLE);
-    lua_setfield(L, -2, "IDLE");
-
-    lua_pushnumber(L, EV_CHILD);
-    lua_setfield(L, -2, "CHILD");
-
-    lua_pushnumber(L, EV_STAT);
-    lua_setfield(L, -2, "STAT");
-
-    lua_pushnumber(L, EV_MINPRI);
-    lua_setfield(L, -2, "MINPRI");
-
-    lua_pushnumber(L, EV_MAXPRI);
-    lua_setfield(L, -2, "MAXPRI");
-
-    lua_pushnumber(L, SIGHUP);
-    lua_setfield(L, -2, "SIGHUP");
-
-    lua_pushnumber(L, SIGINT);
-    lua_setfield(L, -2, "SIGINT");    
-
-    lua_pushnumber(L, SIGQUIT);
-    lua_setfield(L, -2, "SIGQUIT");    
-
-    lua_pushnumber(L, SIGILL);
-    lua_setfield(L, -2, "SIGILL");    
-
-    lua_pushnumber(L, SIGTRAP);
-    lua_setfield(L, -2, "SIGTRAP");    
-
-    lua_pushnumber(L, SIGABRT);
-    lua_setfield(L, -2, "SIGABRT");    
-
-    lua_pushnumber(L, SIGIOT);
-    lua_setfield(L, -2, "SIGIOT");    
-
-    lua_pushnumber(L, SIGBUS);
-    lua_setfield(L, -2, "SIGBUS");    
-
-    lua_pushnumber(L, SIGFPE);
-    lua_setfield(L, -2, "SIGFPE");    
-
-    lua_pushnumber(L, SIGUSR1);
-    lua_setfield(L, -2, "SIGUSR1");
-
-    lua_pushnumber(L, SIGSEGV);
-    lua_setfield(L, -2, "SIGSEGV");    
-
-    lua_pushnumber(L, SIGUSR2);
-    lua_setfield(L, -2, "SIGUSR2");    
-
-    lua_pushnumber(L, SIGPIPE);
-    lua_setfield(L, -2, "SIGPIPE");    
-
-    lua_pushnumber(L, SIGALRM);
-    lua_setfield(L, -2, "SIGALRM");    
-
-    lua_pushnumber(L, SIGTERM);
-    lua_setfield(L, -2, "SIGTERM");    
-
-    lua_pushnumber(L, SIGSTKFLT);
-    lua_setfield(L, -2, "SIGSTKFLT");    
-
-    lua_pushnumber(L, SIGCHLD);
-    lua_setfield(L, -2, "SIGCHLD");    
-
-    lua_pushnumber(L, SIGCONT);
-    lua_setfield(L, -2, "SIGCONT");    
-
-    lua_pushnumber(L, SIGTSTP);
-    lua_setfield(L, -2, "SIGTSTP");    
-
-    lua_pushnumber(L, SIGTTIN);
-    lua_setfield(L, -2, "SIGTTIN");    
-
-    lua_pushnumber(L, SIGTTOU);
-    lua_setfield(L, -2, "SIGTTOU");    
-
-    lua_pushnumber(L, SIGURG);
-    lua_setfield(L, -2, "SIGURG");    
-
-    lua_pushnumber(L, SIGXCPU);
-    lua_setfield(L, -2, "SIGXCPU");    
-
-    lua_pushnumber(L, SIGXFSZ);
-    lua_setfield(L, -2, "SIGXFSZ");    
-
-    lua_pushnumber(L, SIGVTALRM);
-    lua_setfield(L, -2, "SIGVTALRM");    
-
-    lua_pushnumber(L, SIGPROF);
-    lua_setfield(L, -2, "SIGPROF");    
-
-    lua_pushnumber(L, SIGWINCH);
-    lua_setfield(L, -2, "SIGWINCH");    
-
-    lua_pushnumber(L, SIGIO);
-    lua_setfield(L, -2, "SIGIO");    
-
-    lua_pushnumber(L, SIGPOLL);
-    lua_setfield(L, -2, "SIGPOLL");    
-
-    lua_pushnumber(L, SIGPWR);
-    lua_setfield(L, -2, "SIGPWR");    
-
-    lua_pushnumber(L, SIGSYS);
-    lua_setfield(L, -2, "SIGSYS");    
+#undef EV_SETCONST
 
     return 1;
 }
@@ -200,7 +133,7 @@ static int version(lua_State *L) {
 static int traceback(lua_State *L) {
     if ( !lua_isstring(L, 1) ) return 1;
 
-    lua_getfield(L, LUA_GLOBALSINDEX, "debug");
+    lua_getglobal(L, "debug");
     if ( !lua_istable(L, -1) ) {
         lua_pop(L, 1);
         return 1;

--- a/lua_ev.h
+++ b/lua_ev.h
@@ -82,9 +82,13 @@
  * negative stack index into a positive one so that if the stack later
  * grows or shrinks, the index will not be effected.
  */
-#define abs_index(L, i)                    \
-    ((i) > 0 || (i) <= LUA_REGISTRYINDEX ? \
-     (i) : lua_gettop(L) + (i) + 1)
+#if LUA_VERSION_NUM > 501
+#    define abs_index(L, i) lua_absindex(L, i)
+#else
+#    define abs_index(L, i) \
+        ((i) > 0 || (i) <= LUA_REGISTRYINDEX ? \
+        (i) : lua_gettop(L) + (i) + 1)
+#endif
 
 
 /**

--- a/signal_lua_ev.c
+++ b/signal_lua_ev.c
@@ -22,14 +22,18 @@ static int luaopen_ev_signal(lua_State *L) {
  */
 static int create_signal_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "stop",          signal_stop },
         { "start",         signal_start },
         { NULL, NULL }
     };
     luaL_newmetatable(L, SIGNAL_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }

--- a/stat_lua_ev.c
+++ b/stat_lua_ev.c
@@ -22,7 +22,7 @@ static int luaopen_ev_stat(lua_State *L) {
  */
 static int create_stat_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "stop",          stat_stop },
         { "start",         stat_start },
         { "getdata",       stat_getdata },
@@ -30,7 +30,11 @@ static int create_stat_mt(lua_State *L) {
     };
     luaL_newmetatable(L, STAT_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }

--- a/test/dumper.lua
+++ b/test/dumper.lua
@@ -29,7 +29,7 @@ local function dump_impl(input, output, path, indent, done)
    else
       table.insert(output, "[")
       table.insert(output, tostring(input))
-      table.insert(output, "\]");
+      table.insert(output, "]");
    end
 end
 

--- a/timer_lua_ev.c
+++ b/timer_lua_ev.c
@@ -22,7 +22,7 @@ static int luaopen_ev_timer(lua_State *L) {
  */
 static int create_timer_mt(lua_State *L) {
 
-    static luaL_reg fns[] = {
+    static luaL_Reg fns[] = {
         { "again",         timer_again },
         { "stop",          timer_stop },
         { "start",         timer_start },
@@ -31,7 +31,11 @@ static int create_timer_mt(lua_State *L) {
     };
     luaL_newmetatable(L, TIMER_MT);
     add_watcher_mt(L);
+#if LUA_VERSION_NUM > 501
+    luaL_setfuncs(L, fns, 0);
+#else
     luaL_register(L, NULL, fns);
+#endif
 
     return 1;
 }


### PR DESCRIPTION
Hi!  I've been trying to get familiar with libev and libevent through Lua.  I really love what you've written here and I thought I could help by updating it for 5.2!

What Changed:
1) invalid type: luaL_reg -> luaL_Reg
2) luaL_register() has become luaL_setfuncs() & luaL_newlib() respectively
3) getfenv()/setfenv() on userdata became getuservalue()/setuservalue()
4) luaL_typerror() became a private function in 5.2 (upstream-Lua sucks sometimes)
5) dumper.lua was unnecessarily escaping ] which 5.2 didn't like (5.1 did not care)
6) added a FindLua52.cmake for figuring out where liblua.so is
7) made a macro for quicker "constant pushing" in lua_ev.c & alphabetized said constants

I tested building this for Lua 5.1 and 5.2, everything cleared -- all the tests succeeded.  If you want to build for 5.1 again you change the 52 in CMakeLists.txt to 51 and all is happy in the Land of Lua.  Hope you'll accept this :-)
