### PR TITLE
Add async watcher to lua-ev

### DIFF
--- a/README
+++ b/README
@@ -178,6 +178,30 @@ idle = ev.Idle.new(on_idle)
 
     See also ev_idle_init() C function.
 
+async = ev.Async.new(on_async)
+
+    Create a new async watcher that will call the on_async function
+    whenever an application calls ev_async_send() from another context
+    (this can be another thread or some other context which does not
+    control the loop this watcher lives on)
+
+    The returned async is an ev.Async object.  See below for the methods
+    on this object.
+
+    NOTE: You must explicitly register the async with an event loop in
+    order for it to take effect.
+
+    The on_async function will be called with these arguments (return
+    values are ignored):
+
+    on_async(loop, idle, revents)
+
+        The loop is the event loop for which the idle object is
+        registered, the idle parameter is the ev.Idle object, and
+        revents is ev.IDLE.
+
+    See also ev_idle_init() C function.
+
 child = ev.Child.new(on_child, pid, trace)
 
     Create a new child watcher that will call the on_child function
@@ -431,6 +455,23 @@ idle:stop(loop)
 
     See also ev_io_stop() C function (document as ev_TYPE_stop()).
 
+-- ev.Async object methods --
+
+async:start(loop [, is_daemon])
+
+    Start the async watcher in the specified event loop.  Optionally
+    make this watcher a "daemon" watcher which means that the event
+    loop will terminate even if this watcher has not triggered.
+
+    See also ev_async_start() C function (document as ev_TYPE_start()).
+
+async:stop(loop)
+
+    Unregister this async watcher from the specified event loop.
+    Ensures that the watcher is neither active nor pending.
+
+    See also ev_async_stop() C function (document as ev_TYPE_stop()).
+
 -- ev.Child object methods --
 
 child:start(loop [, is_daemon])
@@ -542,5 +583,5 @@ CALLING ev_loop() C API DIRECTLY:
 
 TODO:
 
-  * Add support for other watcher types (periodic, embed, async, etc).
+  * Add support for other watcher types (periodic, embed, etc).
 

--- a/async_lua_ev.c
+++ b/async_lua_ev.c
@@ -1,0 +1,97 @@
+/**
+ * Create a table for ev.Async that gives access to the constructor for
+ * async objects.
+ *
+ * [-0, +1, ?]
+ */
+static int luaopen_ev_async(lua_State *L) {
+    lua_pop(L, create_async_mt(L));
+
+    lua_createtable(L, 0, 1);
+
+    lua_pushcfunction(L, async_new);
+    lua_setfield(L, -2, "new");
+
+    return 1;
+}
+
+/**
+ * Create the async metatable in the registry.
+ *
+ * [-0, +1, ?]
+ */
+static int create_async_mt(lua_State *L) {
+
+    static luaL_Reg fns[] = {
+        { "stop",          async_stop },
+        { "start",         async_start },
+        { NULL, NULL }
+    };
+    luaL_newmetatable(L, ASYNC_MT);
+    add_watcher_mt(L);
+    luaL_setfuncs(L, fns, 0);
+
+    return 1;
+}
+
+/**
+ * Create a new async object.  Arguments:
+ *   1 - callback function.
+ *
+ * @see watcher_new()
+ *
+ * [+1, -0, ?]
+ */
+static int async_new(lua_State* L) {
+    ev_async*  async;
+
+    async = watcher_new(L, sizeof(ev_async), ASYNC_MT);
+    ev_async_init(async, &async_cb );
+    return 1;
+}
+
+/**
+ * @see watcher_cb()
+ *
+ * [+0, -0, m]
+ */
+static void async_cb(struct ev_loop* loop, ev_async* async, int revents) {
+    watcher_cb(loop, async, revents);
+}
+
+/**
+ * Stops the async so it won't be called by the specified event loop.
+ *
+ * Usage:
+ *     async:stop(loop)
+ *
+ * [+0, -0, e]
+ */
+static int async_stop(lua_State *L) {
+    ev_async*       async  = check_async(L, 1);
+    struct ev_loop* loop   = *check_loop_and_init(L, 2);
+
+    loop_stop_watcher(L, 2, 1);
+    ev_async_stop(loop, async);
+
+    return 0;
+}
+
+/**
+ * Starts the async so it won't be called by the specified event loop.
+ *
+ * Usage:
+ *     async:start(loop [, is_daemon])
+ *
+ * [+0, -0, e]
+ */
+static int async_start(lua_State *L) {
+    ev_async*       async  = check_async(L, 1);
+    struct ev_loop* loop   = *check_loop_and_init(L, 2);
+    int is_daemon          = lua_toboolean(L, 3);
+
+    ev_async_start(loop, async);
+    loop_start_watcher(L, 2, 1, is_daemon);
+
+    return 0;
+}

--- a/lua_ev.c
+++ b/lua_ev.c
@@ -15,6 +15,7 @@
 #include "timer_lua_ev.c"
 #include "signal_lua_ev.c"
 #include "idle_lua_ev.c"
+#include "async_lua_ev.c"
 #include "child_lua_ev.c"
 #include "stat_lua_ev.c"
 
@@ -52,6 +53,9 @@ LUALIB_API int luaopen_ev(lua_State *L) {
     luaopen_ev_io(L);
     lua_setfield(L, -2, "IO");
 
+    luaopen_ev_async(L);
+    lua_setfield(L, -2, "Async");
+
     luaopen_ev_signal(L);
     lua_setfield(L, -2, "Signal");
 
@@ -70,6 +74,7 @@ LUALIB_API int luaopen_ev(lua_State *L) {
 
     EV_SETCONST(L, EV_, CHILD);
     EV_SETCONST(L, EV_, IDLE);
+    EV_SETCONST(L, EV_, ASYNC);
     EV_SETCONST(L, EV_, MINPRI);
     EV_SETCONST(L, EV_, MAXPRI);
     EV_SETCONST(L, EV_, READ);

--- a/lua_ev.h
+++ b/lua_ev.h
@@ -35,6 +35,7 @@
  */
 #define LOOP_MT    "ev{loop}"
 #define IO_MT      "ev{io}"
+#define ASYNC_MT   "ev{async}"
 #define TIMER_MT   "ev{timer}"
 #define SIGNAL_MT  "ev{signal}"
 #define IDLE_MT    "ev{idle}"
@@ -79,6 +80,9 @@
 
 #define check_io(L, narg)                                        \
     ((struct ev_io*)       luaL_checkudata((L), (narg), IO_MT))
+
+#define check_async(L, narg)                                        \
+    ((struct ev_async*)    luaL_checkudata((L), (narg), ASYNC_MT))
 
 #define check_signal(L, narg)                                   \
     ((struct ev_signal*)   luaL_checkudata((L), (narg), SIGNAL_MT))
@@ -166,6 +170,16 @@ static void              io_cb(struct ev_loop* loop, ev_io* io, int revents);
 static int               io_stop(lua_State *L);
 static int               io_start(lua_State *L);
 static int               io_getfd(lua_State *L);
+
+/**
+ * Async functions:
+ */
+static int               luaopen_ev_async(lua_State *L);
+static int               create_async_mt(lua_State *L);
+static int               async_new(lua_State* L);
+static void              async_cb(struct ev_loop* loop, ev_async* async, int revents);
+static int               async_stop(lua_State *L);
+static int               async_start(lua_State *L);
 
 /**
  * Signal functions:


### PR DESCRIPTION
Adds support for async watchers. Can be used to create an async watcher
and start or stop it on a given event loop.