### PR TITLE
Remove unnecessary timer check.

### DIFF
--- a/timer_lua_ev.c
+++ b/timer_lua_ev.c
@@ -51,8 +51,6 @@ static int timer_new(lua_State* L) {
     ev_tstamp repeat = luaL_optnumber(L, 3, 0);
     ev_timer* timer;
 
-    if ( after <= 0.0 )
-        luaL_argerror(L, 2, "after must be greater than 0");
     if ( repeat < 0.0 )
         luaL_argerror(L, 3, "repeat must be greater than or equal to 0");
 


### PR DESCRIPTION
See `ev_timer_init` documentation:
  Configure the timer to trigger after "after" seconds (fractional and
  negative values are supported).

An "after" value of 0 can be useful to create a one shot deferred watcher.