### PR TITLE
Changed source URL in rockspec to use git via HTTPS instead of legacy git protocol

### DIFF
--- a/rockspec/lua-ev-scm-1.rockspec
+++ b/rockspec/lua-ev-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-ev"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/brimworks/lua-ev.git"
+   url = "git+https://github.com/brimworks/lua-ev.git"
 }
 
 description = {


### PR DESCRIPTION
Github made a change that went into effect yesterday that disabled `git://` URLs, effectively breaking the existing rockspec files for 1.5 and 1.4. This change is necessary to fix scm-based rockspec files. I'm not entirely sure how the luarocks website works but if the rockspec files for 1.5 and 1.4 can be updated with this same change they can be fixed as well.